### PR TITLE
Fixing issue with the release flow - release notes version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Get release version
-        run: echo "PACKAGE_VERSION=$(cat pyproject.toml|grep ^version|cut -d= -f2|tr -d \")" >> $GITHUB_ENV
+        run: echo "PACKAGE_VERSION=$(cat pyproject.toml|grep ^version|cut -d= -f2|tr -d \"|xargs)" >> $GITHUB_ENV
       - name: Install dependencies
         run: python -m pip install poetry
       - name: Build release
@@ -37,7 +37,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${PACKAGE_VERSION}
+          tag_name: v${{env.PACKAGE_VERSION}}
           release_name: Release v${{env.PACKAGE_VERSION}}
           body_path: releasenotes/${{env.PACKAGE_VERSION}}.md
           draft: false

--- a/foreninglet_data/__init__.py
+++ b/foreninglet_data/__init__.py
@@ -1,1 +1,1 @@
-version = "0.3.2"
+version = "0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "foreninglet-data"
-version = "0.3.2"
+version = "0.3.3"
 description = "A way to retrieve information about members from the ForeningLet API (www.foreninglet.dk) - ForeningLet is a member system for small (typically) voluntary organizations in Denmark"
 authors = ["Carsten Skov <carsten@simcax.dk>"]
 readme = "README.md"

--- a/releasenotes/0.3.3.md
+++ b/releasenotes/0.3.3.md
@@ -1,0 +1,12 @@
+## Release Notes - Version 0.3.0
+
+### New Class Attributes
+
+The following class attributes have been added to the `memberlist` class:
+
+- `new_members_previous_month`: This attribute represents the number of new members in the previous month.
+- `new_members_previous_month_percentage`: This attribute represents the percentage change in new members compared to the previous month.
+- `new_members_current_month`: This attribute represents the number of new members in the current month.
+- `new_members_current_month_percentage`: This attribute represents the percentage change in new members compared to the current month.
+
+Please refer to the updated documentation for more details on how to use these new class attributes.


### PR DESCRIPTION
Removing leading space from the package version in order to be able to find the releasenotes file.